### PR TITLE
fix(issue-13): resolve theming, i18n, layout, and binary-open issues

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1347,16 +1347,6 @@ fn resolve_tool_approval(
     Ok(crate::harness_ai_service::resolve_tool_approval(&tool_call_id, approved, result))
 }
 
-/// 前端审批完成后回调：将审批结果发送给等待中的 stream_chat loop
-#[tauri::command]
-fn resolve_tool_approval(
-    tool_call_id: String,
-    approved: bool,
-    result: Option<String>,
-) -> Result<bool, String> {
-    Ok(crate::harness_ai_service::resolve_tool_approval(&tool_call_id, approved, result))
-}
-
 #[tauri::command]
 async fn ai_completion(
     state: tauri::State<'_, AppState>,

--- a/src/components/Onboarding/OnboardingTour.tsx
+++ b/src/components/Onboarding/OnboardingTour.tsx
@@ -181,7 +181,7 @@ const getTourSteps = (t: (key: string) => string): any[] => {
     },
     // 步骤 4: 布局切换器（定位到布局切换按钮）
     {
-      target: '[data-testid="layout-switcher"]',
+      target: document.querySelector('[data-testid="layout-switcher"]') ? '[data-testid="layout-switcher"]' : 'body',
       content: renderMarkdown(t('onboarding.steps.layoutSwitcher')),
       title: t('onboarding.steps.layoutSwitcherTitle'),
       disableBeacon: false,
@@ -212,8 +212,8 @@ export const OnboardingTour: React.FC<OnboardingTourProps> = ({
       // 目标元素选择器（只检查静态元素）
       const targets = [
         'body',
-        '[data-testid="layout-switcher"]'
-      ];
+        document.querySelector('[data-testid="layout-switcher"]') ? '[data-testid="layout-switcher"]' : null,
+      ].filter(Boolean) as string[];
 
       // 轮询检测目标元素是否存在
       let checkInterval: NodeJS.Timeout | null = null;


### PR DESCRIPTION
## 关联问题
- closes #13

## 概要
本 PR 集中修复 issue #13 中的四类问题：主题与对比度、i18n 文案泄漏、UI/布局缺陷，以及二进制/归档文件被当作文本打开的问题。

## 主要改动
- 统一全局主题语义层：补齐 panel、backdrop、button、input、select、badge、tabs、code surface 等主题语义，收敛明暗主题下的背景、边框、次级文字和交互态。
- 修复多页面 UI/布局问题：覆盖 Chat、Editor、Settings、PromptManager、Tool Explorer、Workflow、FileTree、SnippetManager、Task/Monitor、Onboarding、Help 等页面的按钮、弹层、空状态、加载态、对齐、滚动和层级问题。
- 补齐 i18n 与平台文案：修复 Tool Explorer、Workflow、Task Breakdown 等界面的硬编码文案、原始 key 泄漏和搜索文本本地化问题，并统一快捷键/平台相关文案处理。
- 收敛交互组件风格：统一确认弹窗、复选类组件、列表项状态、工具审批与流式输出区域的视觉风格，避免主题切换后出现不可读或颜色撞底的问题。
- 修复功能性 UX 缺陷：为编辑器文件打开路径增加保护，阻止二进制、压缩包和媒体文件被当作文本直接载入；统一错误提示，并补齐对应单元测试。
- 增强 E2E 支撑：补充 Tool Explorer 相关 Tauri mock，确保当前 PR 覆盖到的 UI 路径可以稳定回归验证。

## 验证
- `npm run check:file`
- `npm run test:run -- tests/unit/v0_3_3/tool-classification.test.ts`
- `npm run test:run -- tests/unit/utils/fileActions.test.ts tests/unit/utils/fileSystemProtection.test.ts`
- `PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/workflow/workflow-dark-theme-validation.spec.ts tests/e2e/workflow/workflow-industrial-design.spec.ts --workers=1 --reporter=line --output=/tmp/ifai-playwright-workflow`
- `PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/section3/tool-explorer-button.spec.ts tests/e2e/ui/console-display-verification.spec.ts --workers=1 --reporter=line`

## 备注
- `playwright.config.ts` 和本地审计/计划清单文件未纳入本 PR。
- 仓库当前 `npm run lint` 未作为门禁使用：脚本中的 ESLint 配置在当前仓库状态下不可直接运行，这不是本 PR 新引入的问题。
